### PR TITLE
:sparkles: Set up log scaffold

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 FRC 3256
 // https://github.com/Team3256
 //
-// Use of this source code is governed by a
+// Use of this source code is governed by a 
 // license that can be found in the LICENSE file at
 // the root directory of this project.
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 FRC 3256
 // https://github.com/Team3256
 //
-// Use of this source code is governed by a
+// Use of this source code is governed by a 
 // license that can be found in the LICENSE file at
 // the root directory of this project.
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 FRC 3256
 // https://github.com/Team3256
 //
-// Use of this source code is governed by a
+// Use of this source code is governed by a 
 // license that can be found in the LICENSE file at
 // the root directory of this project.
 

--- a/src/main/java/frc/robot/utils/NT4PublisherNoFMS.java
+++ b/src/main/java/frc/robot/utils/NT4PublisherNoFMS.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 FRC 3256
+// Copyright (c) 2025 FRC 3256
 // https://github.com/Team3256
 //
 // Use of this source code is governed by a 


### PR DESCRIPTION
- Copied Logging configuration from Kirby
  - Caveat: Monologue isn't installed and `NT4PublisherNoFMS` is still set as a data receiver for `isReal` AdvantageKit logging (regardless of `kLogToUSB`). What are our plans with this? Use WPILib Epilogue?